### PR TITLE
Fix Issue#1: Remove meaningless HTML tags without CSS definitions

### DIFF
--- a/英英英単語１面単語帳/Card-1_FrontTemplate.html
+++ b/英英英単語１面単語帳/Card-1_FrontTemplate.html
@@ -14,62 +14,43 @@
 -->
 
 <!-- 表面 -->
-<div class="card">
-  <div class="front">
-    <div class="question">
-      <div class="card-body">
-        <div class="definition">
-          {{#Definition_SoundFile}}{{Definition_SoundFile}}{{/Definition_SoundFile}}<br>
-					{{{Definition}}<br>
-        </div>
-
-        {{type:Spelling}}
-
-      </div>
-    </div>
-  </div>
+<div class="definition">
+  {{#Definition_SoundFile}}{{Definition_SoundFile}}{{/Definition_SoundFile}}<br>
+  {{{Definition}}<br>
 </div>
 
+{{type:Spelling}}
+
 <!-- 裏面 -->
-<div class="card">
-	<div class="back">
-		<div class="answer">
-			<div class="card-body">
-        {{type:Spelling}}
-        <hr>
-        <div class="word_card">
+{{type:Spelling}}
+<hr>
 
-					<div class="spelling">
-            {{#SoundFile}}{{SoundFile}}{{/SoundFile}}{{Spelling}}<br>
-					</div>
+<div class="spelling">
+  {{#SoundFile}}{{SoundFile}}{{/SoundFile}}{{Spelling}}<br>
+</div>
 
-          <div class="phonetic">
-            {{#PhoneticSymbols}}{{PhoneticSymbols}}{{/PhoneticSymbols}}
-          </div>
+<div class="phonetic">
+  {{#PhoneticSymbols}}{{PhoneticSymbols}}{{/PhoneticSymbols}}
+</div>
 
-					<div class="JP">
-            {{JP}}<br>
-					</div>
+<div class="JP">
+  {{JP}}<br>
+</div>
 
-          <div class="definition">
-            {{#Definition_SoundFile}}{{Definition_SoundFile}}{{/Definition_SoundFile}}<br>
-						{{Definition}}<br>
-          </div>
+<div class="definition">
+  {{#Definition_SoundFile}}{{Definition_SoundFile}}{{/Definition_SoundFile}}<br>
+  {{Definition}}<br>
+</div>
 
-          {{#Image}}{{Image}}{{/Image}}
+{{#Image}}{{Image}}{{/Image}}
 
-          <div class="phrase">
-						<br><hr>
-            {{#Example_SoundFile}}{{Example_SoundFile}}<br>{{/Example_SoundFile}}
-						{{#Example}}{{Example}}<br>{{/Example}}
-						{{#Example_Image}}{{Example_Image}}<br>{{/Example_Image}}
-          </div>
+<div class="phrase">
+  <br><hr>
+  {{#Example_SoundFile}}{{Example_SoundFile}}<br>{{/Example_SoundFile}}
+  {{#Example}}{{Example}}<br>{{/Example}}
+  {{#Example_Image}}{{Example_Image}}<br>{{/Example_Image}}
+</div>
 
-          <div class='extra_note'>
-            {{#Extra_Note}}<br><hr>{{Extra_Note}}{{/Extra_Note}}
-          </div>
-
-        </div>
-		</div>
-	</div>
+<div class='extra_note'>
+  {{#Extra_Note}}<br><hr>{{Extra_Note}}{{/Extra_Note}}
 </div>


### PR DESCRIPTION
- Removed structural tags without CSS: card, front, back, question, answer, card-body, word_card
- Kept semantic tags: definition, spelling, phonetic, JP, phrase, extra_note
- No CSS duplication found (Styling.css is empty)